### PR TITLE
Revise error values

### DIFF
--- a/bmp-string.go
+++ b/bmp-string.go
@@ -1,6 +1,7 @@
 package pkcs12
 
 import (
+	"errors"
 	"unicode/utf16"
 	"unicode/utf8"
 )
@@ -20,7 +21,7 @@ func bmpString(utf8String []byte) ([]byte, error) {
 		c, size := utf8.DecodeRune(utf8String[start:])
 		start += size
 		if t, _ := utf16.EncodeRune(c); t != 0xfffd {
-			return nil, UnsupportedFormat("string contains characters that cannot be encoded in UCS-2")
+			return nil, errors.New("string contains characters that cannot be encoded in UCS-2")
 		}
 		rv = append(rv, byte(c/256), byte(c%256))
 	}
@@ -30,7 +31,7 @@ func bmpString(utf8String []byte) ([]byte, error) {
 
 func decodeBMPString(bmpString []byte) (string, error) {
 	if len(bmpString)%2 != 0 {
-		return "", UnsupportedFormat("expected BMP byte string to be even length")
+		return "", errors.New("expected BMP byte string to be an even length")
 	}
 
 	// strip terminator if present

--- a/crypto.go
+++ b/crypto.go
@@ -8,7 +8,6 @@ import (
 	"crypto/des"
 	"crypto/x509/pkix"
 	"encoding/asn1"
-	"fmt"
 
 	"github.com/dgryski/go-rc2"
 )
@@ -38,7 +37,7 @@ type pbeParams struct {
 func pbDecrypterFor(algorithm pkix.AlgorithmIdentifier, password []byte) (cipher.BlockMode, error) {
 	algorithmName, supported := algByOID[algorithm.Algorithm.String()]
 	if !supported {
-		return nil, UnsupportedFormat("Algorithm " + algorithm.Algorithm.String() + " is not supported")
+		return nil, newNotImplementedError("algorithm " + algorithm.Algorithm.String() + " is not supported")
 	}
 
 	var params pbeParams
@@ -75,11 +74,11 @@ func pbDecrypt(info decryptable, password []byte) (decrypted []byte, err error) 
 		m := decrypted[:len(decrypted)-psLen]
 		ps := decrypted[len(decrypted)-psLen:]
 		if bytes.Compare(ps, bytes.Repeat([]byte{byte(psLen)}, psLen)) != 0 {
-			return nil, fmt.Errorf("decryption error, incorrect padding")
+			return nil, ErrDecryption
 		}
 		decrypted = m
 	} else {
-		return nil, fmt.Errorf("decryption error, incorrect padding")
+		return nil, ErrDecryption
 	}
 
 	return

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/x509/pkix"
 	"encoding/asn1"
-	"fmt"
 	"testing"
 )
 
@@ -23,8 +22,8 @@ func TestPbDecrypterFor(t *testing.T) {
 	pass, _ := bmpString([]byte("Sesame open"))
 
 	_, err := pbDecrypterFor(alg, pass)
-	if err == nil || err.Error() != "Algorithm 1.2.3 is not supported" {
-		t.Errorf("expected different error: %v", err)
+	if _, ok := err.(NotImplementedError); !ok {
+		t.Errorf("expected not implemented error, got: %T %s", err, err)
 	}
 
 	alg.Algorithm = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 1, 3})
@@ -53,8 +52,8 @@ func TestPbDecrypt(t *testing.T) {
 	expected := []interface{}{
 		[]byte("A secret!"),
 		[]byte("A secret"),
-		fmt.Errorf("decryption error, incorrect padding"),
-		fmt.Errorf("decryption error, incorrect padding"),
+		ErrDecryption,
+		ErrDecryption,
 	}
 
 	for i, c := range tests {

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,23 @@
+package pkcs12
+
+import "errors"
+
+var (
+	// ErrDecryption represents a failure to decrypt the input.
+	ErrDecryption = errors.New("pkcs12: decryption error, incorrect padding")
+
+	// ErrIncorrectPassword is returned when an incorrect password is detected.
+	// Usually, P12/PFX data is signed to be able to verify the password.
+	ErrIncorrectPassword = errors.New("pkcs12: decryption password incorrect")
+)
+
+// NotImplementedError indicates that the input is not currently supported.
+type NotImplementedError string
+
+func (e NotImplementedError) Error() string {
+	return string(e)
+}
+
+func newNotImplementedError(text string) error {
+	return NotImplementedError(text)
+}

--- a/mac.go
+++ b/mac.go
@@ -35,7 +35,7 @@ var (
 func verifyMac(macData *macData, message, password []byte) error {
 	name, ok := hashNameByID[macData.Mac.Algorithm.Algorithm.String()]
 	if !ok {
-		return UnsupportedFormat("Unknown digest algorithm: " + macData.Mac.Algorithm.Algorithm.String())
+		return newNotImplementedError("unknown digest algorithm: " + macData.Mac.Algorithm.Algorithm.String())
 	}
 	k := deriveMacKeyByAlg[name](macData.MacSalt, password, macData.Iterations)
 	password = nil
@@ -45,13 +45,7 @@ func verifyMac(macData *macData, message, password []byte) error {
 	expectedMAC := mac.Sum(nil)
 
 	if !hmac.Equal(macData.Mac.Digest, expectedMAC) {
-		return PasswordIncorrect("Incorrect password, MAC mismatch")
+		return ErrIncorrectPassword
 	}
 	return nil
 }
-
-// PasswordIncorrect Error indicates that the supplied password is incorrect.
-// Usually, P12/PFX data is signed to be able to verify the password.
-type PasswordIncorrect string
-
-func (e PasswordIncorrect) Error() string { return string(e) }

--- a/mac_test.go
+++ b/mac_test.go
@@ -2,7 +2,6 @@ package pkcs12
 
 import (
 	"encoding/asn1"
-	"strings"
 	"testing"
 )
 
@@ -20,14 +19,14 @@ func TestVerifyMac(t *testing.T) {
 
 	td.Mac.Algorithm.Algorithm = asn1.ObjectIdentifier([]int{1, 2, 3})
 	err := verifyMac(&td, message, password)
-	if err == nil || strings.Index(err.Error(), "Unknown digest algorithm") != 0 {
+	if _, ok := err.(NotImplementedError); !ok {
 		t.Errorf("err: %v", err)
 	}
 
 	td.Mac.Algorithm.Algorithm = asn1.ObjectIdentifier([]int{1, 3, 14, 3, 2, 26})
 	err = verifyMac(&td, message, password)
-	if err == nil || strings.Index(err.Error(), "Incorrect password") != 0 {
-		t.Errorf("err: %v", err)
+	if err != ErrIncorrectPassword {
+		t.Errorf("Expected incorrect password, got err: %v", err)
 	}
 
 	password, _ = bmpString([]byte("Sesame open"))

--- a/safebags.go
+++ b/safebags.go
@@ -36,23 +36,23 @@ type certBag struct {
 func decodePkcs8ShroudedKeyBag(asn1Data, password []byte) (privateKey interface{}, err error) {
 	pkinfo := new(encryptedPrivateKeyInfo)
 	if _, err = asn1.Unmarshal(asn1Data, pkinfo); err != nil {
-		err = fmt.Errorf("Error decoding PKCS8 shrouded key bag: %v", err)
+		err = fmt.Errorf("error decoding PKCS8 shrouded key bag: %v", err)
 		return nil, err
 	}
 
 	pkData, err := pbDecrypt(pkinfo, password)
 	if err != nil {
-		err = fmt.Errorf("Error decryting PKCS8 shrouded key bag: %v", err)
+		err = fmt.Errorf("error decrypting PKCS8 shrouded key bag: %v", err)
 		return
 	}
 
 	rv := new(asn1.RawValue)
 	if _, err = asn1.Unmarshal(pkData, rv); err != nil {
-		err = fmt.Errorf("could not decode decryted private key data")
+		err = fmt.Errorf("could not decode decrypted private key data")
 	}
 
 	if privateKey, err = x509.ParsePKCS8PrivateKey(pkData); err != nil {
-		err = fmt.Errorf("Error parsing PKCS8 private key: %v", err)
+		err = fmt.Errorf("error parsing PKCS8 private key: %v", err)
 		return nil, err
 	}
 	return
@@ -61,11 +61,11 @@ func decodePkcs8ShroudedKeyBag(asn1Data, password []byte) (privateKey interface{
 func decodeCertBag(asn1Data []byte) (x509Certificates []byte, err error) {
 	bag := new(certBag)
 	if _, err := asn1.Unmarshal(asn1Data, bag); err != nil {
-		err = fmt.Errorf("Error decoding cert bag: %v", err)
+		err = fmt.Errorf("error decoding cert bag: %v", err)
 		return nil, err
 	}
 	if bag.ID.String() != oidCertTypeX509Certificate {
-		return nil, UnsupportedFormat("only X509 certificates are supported")
+		return nil, newNotImplementedError("only X509 certificates are supported")
 	}
 	return bag.Data, nil
 }


### PR DESCRIPTION
### IncorrectPasswordError => ErrIncorrectPassword

Change incorrect password from a type to an error variable and changed name to match golint.

This doesn't match the x509 package: https://github.com/golang/go/blob/master/src/crypto/x509/pem_decrypt.go#L104
(but it's not using the naming convention there)

### UnsupportedFormatError => NotImplementedError

Renamed, ~~and implemented as a struct with a pointer more like [custom error types in the standard library](http://www.goinggo.net/2014/11/error-handling-in-go-part-ii.html).~~