### PR TITLE
Add support for writing PKCS#12 files

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -17,9 +17,14 @@ const (
 	pbewithSHAAnd40BitRC2CBC      = "pbewithSHAAnd40BitRC2-CBC"
 )
 
+var (
+	oidPbeWithSHAAnd3KeyTripleDESCBC = asn1.ObjectIdentifier{1,2,840,113549,1,12,1,3}
+	oidPbewithSHAAnd40BitRC2CBC = asn1.ObjectIdentifier{1,2,840,113549,1,12,1,6}
+)
+
 var algByOID = map[string]string{
-	"1.2.840.113549.1.12.1.3": pbeWithSHAAnd3KeyTripleDESCBC,
-	"1.2.840.113549.1.12.1.6": pbewithSHAAnd40BitRC2CBC,
+	oidPbeWithSHAAnd3KeyTripleDESCBC.String(): pbeWithSHAAnd3KeyTripleDESCBC,
+	oidPbewithSHAAnd40BitRC2CBC.String(): pbewithSHAAnd40BitRC2CBC,
 }
 
 var blockcodeByAlg = map[string]func(key []byte) (cipher.Block, error){

--- a/crypto.go
+++ b/crypto.go
@@ -75,7 +75,7 @@ func pbDecrypt(info decryptable, password []byte) (decrypted []byte, err error) 
 	decrypted = make([]byte, len(encrypted))
 	cbc.CryptBlocks(decrypted, encrypted)
 
-	if psLen := int(decrypted[len(decrypted)-1]); psLen > 0 && psLen < 9 {
+	if psLen := int(decrypted[len(decrypted)-1]); psLen > 0 && psLen <= cbc.BlockSize() {
 		m := decrypted[:len(decrypted)-psLen]
 		ps := decrypted[len(decrypted)-psLen:]
 		if bytes.Compare(ps, bytes.Repeat([]byte{byte(psLen)}, psLen)) != 0 {

--- a/crypto.go
+++ b/crypto.go
@@ -18,13 +18,13 @@ const (
 )
 
 var (
-	oidPbeWithSHAAnd3KeyTripleDESCBC = asn1.ObjectIdentifier{1,2,840,113549,1,12,1,3}
-	oidPbewithSHAAnd40BitRC2CBC = asn1.ObjectIdentifier{1,2,840,113549,1,12,1,6}
+	oidPbeWithSHAAnd3KeyTripleDESCBC = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 12, 1, 3}
+	oidPbewithSHAAnd40BitRC2CBC      = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 12, 1, 6}
 )
 
 var algByOID = map[string]string{
 	oidPbeWithSHAAnd3KeyTripleDESCBC.String(): pbeWithSHAAnd3KeyTripleDESCBC,
-	oidPbewithSHAAnd40BitRC2CBC.String(): pbewithSHAAnd40BitRC2CBC,
+	oidPbewithSHAAnd40BitRC2CBC.String():      pbewithSHAAnd40BitRC2CBC,
 }
 
 var blockcodeByAlg = map[string]func(key []byte) (cipher.Block, error){
@@ -117,8 +117,8 @@ func pbEncrypt(info encryptable, decrypted []byte, password []byte) error {
 		return err
 	}
 
-	psLen := cbc.BlockSize() - len(decrypted) % cbc.BlockSize()
-	encrypted := make([]byte, len(decrypted) + psLen)
+	psLen := cbc.BlockSize() - len(decrypted)%cbc.BlockSize()
+	encrypted := make([]byte, len(decrypted)+psLen)
 	copy(encrypted[:len(decrypted)], decrypted)
 	copy(encrypted[len(decrypted):], bytes.Repeat([]byte{byte(psLen)}, psLen))
 	cbc.CryptBlocks(encrypted, encrypted)

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -41,6 +41,40 @@ func TestPbDecrypterFor(t *testing.T) {
 	}
 }
 
+func TestPbEncrypterFor(t *testing.T) {
+	params, _ := asn1.Marshal(pbeParams{
+		Salt:       []byte{1, 2, 3, 4, 5, 6, 7, 8},
+		Iterations: 2048,
+	})
+	alg := pkix.AlgorithmIdentifier{
+		Algorithm: asn1.ObjectIdentifier([]int{1, 2, 3}),
+		Parameters: asn1.RawValue{
+			FullBytes: params,
+		},
+	}
+
+	pass, _ := bmpString([]byte("Sesame open"))
+
+	_, err := pbEncrypterFor(alg, pass)
+	if _, ok := err.(NotImplementedError); !ok {
+		t.Errorf("expected not implemented error, got: %T %s", err, err)
+	}
+
+	alg.Algorithm = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 1, 3})
+	cbc, err := pbEncrypterFor(alg, pass)
+	if err != nil {
+		t.Errorf("err: %v", err)
+	}
+
+	expectedM := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	M := []byte{185, 73, 135, 249, 137, 1, 122, 247}
+	cbc.CryptBlocks(M, M)
+
+	if bytes.Compare(M, expectedM) != 0 {
+		t.Errorf("expected M to be '%d', but found '%d", expectedM, M)
+	}
+}
+
 func TestPbDecrypt(t *testing.T) {
 
 	tests := [][]byte{
@@ -87,6 +121,40 @@ func TestPbDecrypt(t *testing.T) {
 	}
 }
 
+func TestPbEncrypt(t *testing.T) {
+
+	tests := [][]byte{
+		[]byte("A secret!"),
+		[]byte("A secret"),
+	}
+	expected := [][]byte{
+		[]byte("\x33\x73\xf3\x9f\xda\x49\xae\xfc\xa0\x9a\xdf\x5a\x58\xa0\xea\x46"), // 7 padding bytes
+		[]byte("\x33\x73\xf3\x9f\xda\x49\xae\xfc\x96\x24\x2f\x71\x7e\x32\x3f\xe7"), // 8 padding bytes
+	}
+
+	for i, c := range tests {
+		td := testDecryptable{
+			algorithm: pkix.AlgorithmIdentifier{
+				Algorithm: asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 1, 3}), // SHA1/3TDES
+				Parameters: pbeParams{
+					Salt:       []byte("\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8"),
+					Iterations: 4096,
+				}.RawASN1(),
+			},
+		}
+		p, _ := bmpString([]byte("sesame"))
+
+		err := pbEncrypt(&td, c, p)
+		if err != nil {
+			t.Errorf("error encrypting %d: %v", c, err)
+		}
+
+		if bytes.Compare(td.data, expected[i]) != 0 {
+			t.Errorf("expected %d to be encrypted to %d, but found %d", c, expected[i], td.data)
+		}
+	}
+}
+
 type testDecryptable struct {
 	data      []byte
 	algorithm pkix.AlgorithmIdentifier
@@ -94,6 +162,7 @@ type testDecryptable struct {
 
 func (d testDecryptable) GetAlgorithm() pkix.AlgorithmIdentifier { return d.algorithm }
 func (d testDecryptable) GetData() []byte                        { return d.data }
+func (d *testDecryptable) SetData(data []byte)                   { d.data = data }
 
 func (params pbeParams) RawASN1() (raw asn1.RawValue) {
 	asn1Bytes, err := asn1.Marshal(params)

--- a/mac.go
+++ b/mac.go
@@ -51,3 +51,17 @@ func verifyMac(macData *macData, message, password []byte) error {
 	}
 	return nil
 }
+
+func computeMac(macData *macData, message, password []byte) error {
+	name, ok := hashNameByID[macData.Mac.Algorithm.Algorithm.String()]
+	if !ok {
+		return NotImplementedError("unknown digest algorithm: " + macData.Mac.Algorithm.Algorithm.String())
+	}
+	k := deriveMacKeyByAlg[name](macData.MacSalt, password, macData.Iterations)
+	password = nil
+
+	mac := hmac.New(hashByName[name], k)
+	mac.Write(message)
+	macData.Mac.Digest = mac.Sum(nil)
+	return nil
+}

--- a/mac.go
+++ b/mac.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"hash"
 )
 
@@ -24,8 +25,9 @@ const (
 )
 
 var (
+	oidSha1Algorithm = asn1.ObjectIdentifier{1,3,14,3,2,26}
 	hashNameByID = map[string]string{
-		"1.3.14.3.2.26": sha1Algorithm,
+		oidSha1Algorithm.String(): sha1Algorithm,
 	}
 	hashByName = map[string]func() hash.Hash{
 		sha1Algorithm: sha1.New,

--- a/mac.go
+++ b/mac.go
@@ -25,8 +25,8 @@ const (
 )
 
 var (
-	oidSha1Algorithm = asn1.ObjectIdentifier{1,3,14,3,2,26}
-	hashNameByID = map[string]string{
+	oidSha1Algorithm = asn1.ObjectIdentifier{1, 3, 14, 3, 2, 26}
+	hashNameByID     = map[string]string{
 		oidSha1Algorithm.String(): sha1Algorithm,
 	}
 	hashByName = map[string]func() hash.Hash{

--- a/mac_test.go
+++ b/mac_test.go
@@ -1,9 +1,9 @@
 package pkcs12
 
 import (
+	"bytes"
 	"encoding/asn1"
 	"testing"
-	"bytes"
 )
 
 func TestVerifyMac(t *testing.T) {

--- a/mac_test.go
+++ b/mac_test.go
@@ -3,6 +3,7 @@ package pkcs12
 import (
 	"encoding/asn1"
 	"testing"
+	"bytes"
 )
 
 func TestVerifyMac(t *testing.T) {
@@ -33,6 +34,35 @@ func TestVerifyMac(t *testing.T) {
 	err = verifyMac(&td, message, password)
 	if err != nil {
 		t.Errorf("err: %v", err)
+	}
+
+}
+
+func TestComputeMac(t *testing.T) {
+	td := macData{
+		MacSalt:    []byte{1, 2, 3, 4, 5, 6, 7, 8},
+		Iterations: 2048,
+	}
+
+	message := []byte{11, 12, 13, 14, 15}
+	password, _ := bmpString([]byte("Sesame open"))
+
+	td.Mac.Algorithm.Algorithm = asn1.ObjectIdentifier([]int{1, 2, 3})
+	err := computeMac(&td, message, password)
+	if _, ok := err.(NotImplementedError); !ok {
+		t.Errorf("err: %v", err)
+	}
+
+	td.Mac.Algorithm.Algorithm = asn1.ObjectIdentifier([]int{1, 3, 14, 3, 2, 26})
+	err = computeMac(&td, message, password)
+	if err != nil {
+		t.Errorf("err: %v", err)
+	}
+
+	expectedDigest := []byte{0x18, 0x20, 0x3d, 0xff, 0x1e, 0x16, 0xf4, 0x92, 0xf2, 0xaf, 0xc8, 0x91, 0xa9, 0xba, 0xd6, 0xca, 0x9d, 0xee, 0x51, 0x93}
+
+	if bytes.Compare(td.Mac.Digest, expectedDigest) != 0 {
+		t.Errorf("Computed incorrect MAC; expected MAC to be '%d' but got '%d'", expectedDigest, td.Mac.Digest)
 	}
 
 }

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -30,8 +30,8 @@ type contentInfo struct {
 }
 
 var (
-	oidDataContentType          = asn1.ObjectIdentifier{1,2,840,113549,1,7,1}
-	oidEncryptedDataContentType = asn1.ObjectIdentifier{1,2,840,113549,1,7,6}
+	oidDataContentType          = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 1}
+	oidEncryptedDataContentType = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 6}
 )
 
 type encryptedData struct {
@@ -71,7 +71,7 @@ type encryptedPrivateKeyInfo struct {
 func (i encryptedPrivateKeyInfo) GetAlgorithm() pkix.AlgorithmIdentifier { return i.AlgorithmIdentifier }
 func (i encryptedPrivateKeyInfo) GetData() []byte                        { return i.EncryptedData }
 
-func (i *encryptedPrivateKeyInfo) SetData(data []byte)                    { i.EncryptedData = data }
+func (i *encryptedPrivateKeyInfo) SetData(data []byte) { i.EncryptedData = data }
 
 // PEM block types
 const (
@@ -156,9 +156,9 @@ func convertBag(bag *safeBag, password []byte) (*pem.Block, error) {
 }
 
 var (
-	oidFriendlyName     = asn1.ObjectIdentifier{1,2,840,113549,1,9,20}
-	oidLocalKeyID       = asn1.ObjectIdentifier{1,2,840,113549,1,9,21}
-	oidMicrosoftCSPName = asn1.ObjectIdentifier{1,3,6,1,4,1,311,17,1}
+	oidFriendlyName     = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 20}
+	oidLocalKeyID       = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 21}
+	oidMicrosoftCSPName = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 17, 1}
 )
 
 var attributeNameByOID = map[string]string{
@@ -329,7 +329,7 @@ func getSafeContents(p12Data, password []byte) (bags []safeBag, actualPassword [
 // and contains the certificates, and another that is unencrypted and contains the private key shrouded with 3DES.
 // The private key bag and the end-entity certificate bag have the LocalKeyId attribute set to the SHA-1 fingerprint
 // of the end-entity certificate.
-func Encode (privateKey interface{}, certificate *x509.Certificate, caCerts []*x509.Certificate, utf8Password []byte) (pfxData []byte, err error) {
+func Encode(privateKey interface{}, certificate *x509.Certificate, caCerts []*x509.Certificate, utf8Password []byte) (pfxData []byte, err error) {
 	p, err := bmpString(utf8Password)
 
 	if err != nil {
@@ -420,7 +420,7 @@ func Encode (privateKey interface{}, certificate *x509.Certificate, caCerts []*x
 	return
 }
 
-func makeCertBag (certBytes []byte, attributes []pkcs12Attribute) (certBag *safeBag, err error) {
+func makeCertBag(certBytes []byte, attributes []pkcs12Attribute) (certBag *safeBag, err error) {
 	certBag = new(safeBag)
 	certBag.ID = oidCertBagType
 	certBag.Value.Class = 2
@@ -433,7 +433,7 @@ func makeCertBag (certBytes []byte, attributes []pkcs12Attribute) (certBag *safe
 	return
 }
 
-func makeSafeContents (bags []safeBag, password []byte) (ci contentInfo, err error) {
+func makeSafeContents(bags []safeBag, password []byte) (ci contentInfo, err error) {
 	var data []byte
 	if data, err = asn1.Marshal(bags); err != nil {
 		return

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -328,13 +328,16 @@ func getSafeContents(p12Data, password []byte) (bags []safeBag, actualPassword [
 func Encode (privateKey interface{}, certificate *x509.Certificate, caCerts []*x509.Certificate, utf8Password []byte) (pfxData []byte, err error) {
 	p, err := bmpString(utf8Password)
 
-	for i := 0; i < len(utf8Password); i++ {
-		utf8Password[i] = 0
-	}
-
 	if err != nil {
 		return nil, err
 	}
+
+	defer func() { // clear out BMP version of the password before we return
+		for i := 0; i < len(p); i++ {
+			p[i] = 0
+		}
+	}()
+
 
 	var pfx pfxPdu
 	pfx.Version = 3

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -324,7 +324,11 @@ func getSafeContents(p12Data, password []byte) (bags []safeBag, actualPassword [
 	return
 }
 
-// Encode produces pfxData containing one private key, a more certificate, and any number of CA certificates
+// Encode produces pfxData containing one private key, an end-entity certificate, and any number of CA certificates
+// It emulates the behavior of OpenSSL's PKCS12_create: it creates two SafeContents: one that's encrypted with RC2
+// and contains the certificates, and another that is unencrypted and contains the private key shrouded with 3DES.
+// The private key bag and the end-entity certificate bag have the LocalKeyId attribute set to the SHA-1 fingerprint
+// of the end-entity certificate.
 func Encode (privateKey interface{}, certificate *x509.Certificate, caCerts []*x509.Certificate, utf8Password []byte) (pfxData []byte, err error) {
 	p, err := bmpString(utf8Password)
 
@@ -337,7 +341,6 @@ func Encode (privateKey interface{}, certificate *x509.Certificate, caCerts []*x
 			p[i] = 0
 		}
 	}()
-
 
 	var pfx pfxPdu
 	pfx.Version = 3

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -364,7 +364,7 @@ func Encode (privateKey interface{}, certificate *x509.Certificate, caCerts []*x
 	}
 
 	var keyBag safeBag
-	keyBag.ID = asn1.ObjectIdentifier{1,2,840,113549,1,12,10,1,2} // TODO: don't hard code pkcs8ShroudedKeyBagType OID
+	keyBag.ID = oidPkcs8ShroudedKeyBagType
 	keyBag.Value.Class = 2
 	keyBag.Value.Tag = 0
 	keyBag.Value.IsCompound = true
@@ -394,7 +394,7 @@ func Encode (privateKey interface{}, certificate *x509.Certificate, caCerts []*x
 	}
 
 	// compute the MAC
-	pfx.MacData.Mac.Algorithm.Algorithm = asn1.ObjectIdentifier{1,3,14,3,2,26}; // TODO: don't hard-code OID for SHA-1
+	pfx.MacData.Mac.Algorithm.Algorithm = oidSha1Algorithm
 	pfx.MacData.MacSalt = make([]byte, 8)
 	if _, err = rand.Read(pfx.MacData.MacSalt); err != nil {
 		return nil, err
@@ -420,7 +420,7 @@ func Encode (privateKey interface{}, certificate *x509.Certificate, caCerts []*x
 
 func makeCertBag (certBytes []byte, attributes []pkcs12Attribute) (certBag *safeBag, err error) {
 	certBag = new(safeBag)
-	certBag.ID = asn1.ObjectIdentifier{1,2,840,113549,1,12,10,1,3} // TODO: don't hard code certBagType OID
+	certBag.ID = oidCertBagType
 	certBag.Value.Class = 2
 	certBag.Value.Tag = 0
 	certBag.Value.IsCompound = true
@@ -452,7 +452,7 @@ func makeSafeContents (bags []safeBag, password []byte) (ci contentInfo, err err
 		}
 
 		var algo pkix.AlgorithmIdentifier
-		algo.Algorithm = asn1.ObjectIdentifier{1,2,840,113549,1,12,1,6} // TODO: don't hard code RC2 OID
+		algo.Algorithm = oidPbewithSHAAnd40BitRC2CBC
 		if algo.Parameters.FullBytes, err = asn1.Marshal(pbeParams{Salt: randomSalt, Iterations: 2048}); err != nil {
 			return
 		}

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -27,9 +27,9 @@ type contentInfo struct {
 	Content     asn1.RawValue `asn1:"tag:0,explicit,optional"`
 }
 
-const (
-	oidDataContentType          = "1.2.840.113549.1.7.1"
-	oidEncryptedDataContentType = "1.2.840.113549.1.7.6"
+var (
+	oidDataContentType          = asn1.ObjectIdentifier{1,2,840,113549,1,7,1}
+	oidEncryptedDataContentType = asn1.ObjectIdentifier{1,2,840,113549,1,7,6}
 )
 
 type encryptedData struct {
@@ -116,16 +116,15 @@ func convertBag(bag *safeBag, password []byte) (*pem.Block, error) {
 		b.Headers[k] = v
 	}
 
-	bagType := bagTypeNameByOID[bag.ID.String()]
-	switch bagType {
-	case certBagType:
+	switch {
+	case bag.ID.Equal(oidCertBagType):
 		b.Type = CertificateType
 		certsData, err := decodeCertBag(bag.Value.Bytes)
 		if err != nil {
 			return nil, err
 		}
 		b.Bytes = certsData
-	case pkcs8ShroudedKeyBagType:
+	case bag.ID.Equal(oidPkcs8ShroudedKeyBagType):
 		b.Type = PrivateKeyType
 
 		key, err := decodePkcs8ShroudedKeyBag(bag.Value.Bytes, password)
@@ -150,32 +149,31 @@ func convertBag(bag *safeBag, password []byte) (*pem.Block, error) {
 	return b, nil
 }
 
-const (
-	oidFriendlyName     = "1.2.840.113549.1.9.20"
-	oidLocalKeyID       = "1.2.840.113549.1.9.21"
-	oidMicrosoftCSPName = "1.3.6.1.4.1.311.17.1"
+var (
+	oidFriendlyName     = asn1.ObjectIdentifier{1,2,840,113549,1,9,20}
+	oidLocalKeyID       = asn1.ObjectIdentifier{1,2,840,113549,1,9,21}
+	oidMicrosoftCSPName = asn1.ObjectIdentifier{1,3,6,1,4,1,311,17,1}
 )
 
 var attributeNameByOID = map[string]string{
-	oidFriendlyName:     "friendlyName",
-	oidLocalKeyID:       "localKeyId",
-	oidMicrosoftCSPName: "Microsoft CSP Name", // openssl-compatible
+	oidFriendlyName.String():     "friendlyName",
+	oidLocalKeyID.String():       "localKeyId",
+	oidMicrosoftCSPName.String(): "Microsoft CSP Name", // openssl-compatible
 }
 
 func convertAttribute(attribute *pkcs12Attribute) (key, value string, err error) {
-	oid := attribute.ID.String()
-	key = attributeNameByOID[oid]
-	switch oid {
-	case oidMicrosoftCSPName:
+	key = attributeNameByOID[attribute.ID.String()]
+	switch {
+	case attribute.ID.Equal(oidMicrosoftCSPName):
 		fallthrough
-	case oidFriendlyName:
+	case attribute.ID.Equal(oidFriendlyName):
 		if _, err = asn1.Unmarshal(attribute.Value.Bytes, &attribute.Value); err != nil {
 			return
 		}
 		if value, err = decodeBMPString(attribute.Value.Bytes); err != nil {
 			return
 		}
-	case oidLocalKeyID:
+	case attribute.ID.Equal(oidLocalKeyID):
 		id := new([]byte)
 		if _, err = asn1.Unmarshal(attribute.Value.Bytes, id); err != nil {
 			return
@@ -213,10 +211,8 @@ func Decode(pfxData, utf8Password []byte) (privateKey interface{}, certificate *
 	}
 
 	for _, bag := range bags {
-		bagType := bagTypeNameByOID[bag.ID.String()]
-
-		switch bagType {
-		case certBagType:
+		switch {
+		case bag.ID.Equal(oidCertBagType):
 			certsData, err := decodeCertBag(bag.Value.Bytes)
 			if err != nil {
 				return nil, nil, err
@@ -230,7 +226,7 @@ func Decode(pfxData, utf8Password []byte) (privateKey interface{}, certificate *
 				return nil, nil, err
 			}
 			certificate = certs[0]
-		case pkcs8ShroudedKeyBagType:
+		case bag.ID.Equal(oidPkcs8ShroudedKeyBagType):
 			if privateKey, err = decodePkcs8ShroudedKeyBag(bag.Value.Bytes, p); err != nil {
 				return nil, nil, err
 			}
@@ -257,7 +253,7 @@ func getSafeContents(p12Data, password []byte) (bags []safeBag, actualPassword [
 		return nil, nil, NotImplementedError("can only decode v3 PFX PDU's")
 	}
 
-	if pfx.AuthSafe.ContentType.String() != oidDataContentType {
+	if !pfx.AuthSafe.ContentType.Equal(oidDataContentType) {
 		return nil, nil, NotImplementedError("only password-protected PFX is implemented")
 	}
 
@@ -293,12 +289,12 @@ func getSafeContents(p12Data, password []byte) (bags []safeBag, actualPassword [
 
 	for _, ci := range authenticatedSafe {
 		var data []byte
-		switch ci.ContentType.String() {
-		case oidDataContentType:
+		switch {
+		case ci.ContentType.Equal(oidDataContentType):
 			if _, err = asn1.Unmarshal(ci.Content.Bytes, &data); err != nil {
 				return
 			}
-		case oidEncryptedDataContentType:
+		case ci.ContentType.Equal(oidEncryptedDataContentType):
 			var encryptedData encryptedData
 			if _, err = asn1.Unmarshal(ci.Content.Bytes, &encryptedData); err != nil {
 				return

--- a/pkcs8.go
+++ b/pkcs8.go
@@ -27,6 +27,7 @@ var ( // Duplicated from x509 package
 	oidNamedCurveP384 = asn1.ObjectIdentifier{1, 3, 132, 0, 34}
 	oidNamedCurveP521 = asn1.ObjectIdentifier{1, 3, 132, 0, 35}
 )
+
 func oidFromNamedCurve(curve elliptic.Curve) (asn1.ObjectIdentifier, bool) { // Duplicated from x509 package
 	switch curve {
 	case elliptic.P224():
@@ -42,7 +43,7 @@ func oidFromNamedCurve(curve elliptic.Curve) (asn1.ObjectIdentifier, bool) { // 
 	return nil, false
 }
 
-func marshalPKCS8PrivateKey (key interface{}) (der []byte, err error) {
+func marshalPKCS8PrivateKey(key interface{}) (der []byte, err error) {
 	var privKey pkcs8
 	switch key := key.(type) {
 	case *rsa.PrivateKey:
@@ -65,4 +66,3 @@ func marshalPKCS8PrivateKey (key interface{}) (der []byte, err error) {
 	}
 	return asn1.Marshal(privKey)
 }
-

--- a/pkcs8.go
+++ b/pkcs8.go
@@ -1,0 +1,68 @@
+package pkcs12
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+)
+
+type pkcs8 struct { // Duplicated from x509 package
+	Version    int
+	Algo       pkix.AlgorithmIdentifier
+	PrivateKey []byte
+}
+
+var ( // Duplicated from x509 package
+	oidPublicKeyRSA   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
+	oidPublicKeyECDSA = asn1.ObjectIdentifier{1, 2, 840, 10045, 2, 1}
+)
+
+var ( // Duplicated from x509 package
+	oidNamedCurveP224 = asn1.ObjectIdentifier{1, 3, 132, 0, 33}
+	oidNamedCurveP256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7}
+	oidNamedCurveP384 = asn1.ObjectIdentifier{1, 3, 132, 0, 34}
+	oidNamedCurveP521 = asn1.ObjectIdentifier{1, 3, 132, 0, 35}
+)
+func oidFromNamedCurve(curve elliptic.Curve) (asn1.ObjectIdentifier, bool) { // Duplicated from x509 package
+	switch curve {
+	case elliptic.P224():
+		return oidNamedCurveP224, true
+	case elliptic.P256():
+		return oidNamedCurveP256, true
+	case elliptic.P384():
+		return oidNamedCurveP384, true
+	case elliptic.P521():
+		return oidNamedCurveP521, true
+	}
+
+	return nil, false
+}
+
+func marshalPKCS8PrivateKey (key interface{}) (der []byte, err error) {
+	var privKey pkcs8
+	switch key := key.(type) {
+	case *rsa.PrivateKey:
+		privKey.Algo.Algorithm = oidPublicKeyRSA
+		privKey.PrivateKey = x509.MarshalPKCS1PrivateKey(key)
+	case *ecdsa.PrivateKey:
+		privKey.Algo.Algorithm = oidPublicKeyECDSA
+		namedCurveOID, ok := oidFromNamedCurve(key.Curve)
+		if !ok {
+			return nil, errors.New("x509: unknown elliptic curve")
+		}
+		if privKey.Algo.Parameters.FullBytes, err = asn1.Marshal(namedCurveOID); err != nil {
+			return nil, errors.New("x509: failed to embed OID of named curve in PKCS#8: " + err.Error())
+		}
+		if privKey.PrivateKey, err = x509.MarshalECPrivateKey(key); err != nil {
+			return nil, errors.New("x509: failed to embed EC private key in PKCS#8: " + err.Error())
+		}
+	default:
+		return nil, errors.New("x509: only RSA and ECDSA private keys supported")
+	}
+	return asn1.Marshal(privKey)
+}
+

--- a/safebags.go
+++ b/safebags.go
@@ -9,17 +9,17 @@ import (
 
 //see https://tools.ietf.org/html/rfc7292#appendix-D
 var (
-	oidKeyBagType = asn1.ObjectIdentifier{1,2,840,113549,1,12,10,1,1}
-	oidPkcs8ShroudedKeyBagType = asn1.ObjectIdentifier{1,2,840,113549,1,12,10,1,2}
-	oidCertBagType = asn1.ObjectIdentifier{1,2,840,113549,1,12,10,1,3}
-	oidCrlBagType = asn1.ObjectIdentifier{1,2,840,113549,1,12,10,1,4}
-	oidSecretBagType = asn1.ObjectIdentifier{1,2,840,113549,1,12,10,1,5}
-	oidSafeContentsBagType = asn1.ObjectIdentifier{1,2,840,113549,1,12,10,1,6}
+	oidKeyBagType              = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 12, 10, 1, 1}
+	oidPkcs8ShroudedKeyBagType = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 12, 10, 1, 2}
+	oidCertBagType             = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 12, 10, 1, 3}
+	oidCrlBagType              = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 12, 10, 1, 4}
+	oidSecretBagType           = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 12, 10, 1, 5}
+	oidSafeContentsBagType     = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 12, 10, 1, 6}
 )
 
 var (
-	oidCertTypeX509Certificate = asn1.ObjectIdentifier{1,2,840,113549,1,9,22,1}
-	oidLocalKeyIDAttribute     = asn1.ObjectIdentifier{1,2,840,113549,1,9,21}
+	oidCertTypeX509Certificate = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 22, 1}
+	oidLocalKeyIDAttribute     = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 21}
 )
 
 type certBag struct {

--- a/safebags.go
+++ b/safebags.go
@@ -7,25 +7,18 @@ import (
 )
 
 //see https://tools.ietf.org/html/rfc7292#appendix-D
-var bagTypeNameByOID = map[string]string{
-	"1.2.840.113549.1.12.10.1.1": keyBagType,
-	"1.2.840.113549.1.12.10.1.2": pkcs8ShroudedKeyBagType,
-	"1.2.840.113549.1.12.10.1.3": certBagType,
-	"1.2.840.113549.1.12.10.1.4": crlBagType,
-	"1.2.840.113549.1.12.10.1.5": secretBagType,
-	"1.2.840.113549.1.12.10.1.6": safeContentsBagType,
-}
+var (
+	oidKeyBagType = asn1.ObjectIdentifier{1,2,840,113549,1,12,10,1,1}
+	oidPkcs8ShroudedKeyBagType = asn1.ObjectIdentifier{1,2,840,113549,1,12,10,1,2}
+	oidCertBagType = asn1.ObjectIdentifier{1,2,840,113549,1,12,10,1,3}
+	oidCrlBagType = asn1.ObjectIdentifier{1,2,840,113549,1,12,10,1,4}
+	oidSecretBagType = asn1.ObjectIdentifier{1,2,840,113549,1,12,10,1,5}
+	oidSafeContentsBagType = asn1.ObjectIdentifier{1,2,840,113549,1,12,10,1,6}
+)
 
-const (
-	keyBagType              = "keyBag"
-	pkcs8ShroudedKeyBagType = "pkcs8ShroudedKeyBag"
-	certBagType             = "certBag"
-	crlBagType              = "crlBag"
-	secretBagType           = "secretBag"
-	safeContentsBagType     = "safeContentsBag"
-
-	oidCertTypeX509Certificate = "1.2.840.113549.1.9.22.1"
-	oidLocalKeyIDAttribute     = "1.2.840.113549.1.9.21"
+var (
+	oidCertTypeX509Certificate = asn1.ObjectIdentifier{1,2,840,113549,1,9,22,1}
+	oidLocalKeyIDAttribute     = asn1.ObjectIdentifier{1,2,840,113549,1,9,21}
 )
 
 type certBag struct {
@@ -64,7 +57,7 @@ func decodeCertBag(asn1Data []byte) (x509Certificates []byte, err error) {
 		err = fmt.Errorf("error decoding cert bag: %v", err)
 		return nil, err
 	}
-	if bag.ID.String() != oidCertTypeX509Certificate {
+	if !bag.ID.Equal(oidCertTypeX509Certificate) {
 		return nil, NotImplementedError("only X509 certificates are supported")
 	}
 	return bag.Data, nil

--- a/safebags.go
+++ b/safebags.go
@@ -68,7 +68,7 @@ func encodePkcs8ShroudedKeyBag(privateKey interface{}, password []byte) (asn1Dat
 	}
 
 	var pkinfo encryptedPrivateKeyInfo
-	pkinfo.AlgorithmIdentifier.Algorithm = asn1.ObjectIdentifier{1,2,840,113549,1,12,1,3} // TODO: don't hard code 3DES OID
+	pkinfo.AlgorithmIdentifier.Algorithm = oidPbeWithSHAAnd3KeyTripleDESCBC
 	pkinfo.AlgorithmIdentifier.Parameters.FullBytes = paramBytes
 
 	if err = pbEncrypt(&pkinfo, pkData, password); err != nil {


### PR DESCRIPTION
These commits add a `pkcs12.Encode` function that creates a PKCS#12 file containing a private key, an end-entity certificate, and any number of CA certificates.  Encode emulates the behavior of OpenSSL's `PKCS12_create` function: it creates two SafeContents: one that's encrypted with RC2 and contains the certificates, and another that is unencrypted and contains the private key shrouded with 3DES.  The private key bag and the end-entity certificate bag have the LocalKeyId attribute set to the SHA-1 fingerprint of the end-entity certificate.
